### PR TITLE
Thread.sleep() ersetzt, loaded-Anzeige

### DIFF
--- a/web/clerk.css
+++ b/web/clerk.css
@@ -69,3 +69,18 @@ th, td {
 th {
     background-color: #f2f2f2;
 }
+ 
+.load-message {
+    position: fixed;
+    bottom: 10px; /* Adjust spacing from the bottom */
+    right: 10px; /* Adjust spacing from the right */
+    background-color: rgba(144, 238, 144, 0.7); /* Light green background */
+    color: rgba(0, 0, 0); /* Black font color */
+    padding: 0px; /* Reduced padding */
+    font-family: 'Courier New', Courier, monospace; /* Typewriter-style font */
+    font-size: 10px; /* Smaller font size */
+    display: none; /* Initially hidden */
+    z-index: 1000; /* Ensure it stays on top */
+    border-radius: 5px; /* rounded corners */
+}
+  

--- a/web/index.html
+++ b/web/index.html
@@ -11,5 +11,6 @@
   </head>
   <body>
     <div id="events"></div>
+    <div id="loadMessage" class="load-message"> loading… </div>
   </body>
 </html>

--- a/web/script.js
+++ b/web/script.js
@@ -1,3 +1,5 @@
+const loadedDiv = document.getElementById('loadMessage');  
+
 function setUp() {
   if (window.EventSource) {
     const source = new EventSource("/events");
@@ -8,10 +10,7 @@ function setUp() {
       const data = event.data.slice(splitPos + 1).replaceAll("\\n", "\n");
 
       switch (action) {
-        case "script":
-          Function(data).apply(); // https://www.educative.io/answers/eval-vs-function-in-javascript
-          break;
-        case "scriptV2": {
+        case "script": {
           const newElement = document.createElement("script");
           newElement.innerHTML = data;
           document.body.appendChild(newElement);
@@ -24,12 +23,16 @@ function setUp() {
           break;
         }
         case "load": {
+          loadedDiv.style.display = 'block';
           const newElement = document.createElement("script");
           newElement.src = data;
           newElement.onload = function (_) {
             fetch("/loaded", {method: "post"}).catch(console.log);
           }
           document.body.appendChild(newElement);
+          setTimeout(() => {
+            loadedDiv.style.display = 'none';
+          }, 100);
           break;
         }
         default:
@@ -42,11 +45,14 @@ function setUp() {
       console.error("EventSource failed:", error);
       source.close();
     };
+
   } else {
     document.getElementById("events").innerHTML =
       "Your browser does not support Server-Sent Events.";
   }
 }
 
-const Clerk = {};
+const Clerk = {}; // not used, yet
 setUp();
+
+// https://samthor.au/2020/understanding-load/


### PR DESCRIPTION
* Die von Ramon erarbeitete `scriptV2`-Methode ersetzt die alte `script`-Methode
* Zur Synchronisation bei einem `sendAndWait`: Das Polling über ein `while` und die boolsche Variable `isBlocking` ist durch `CyclicBarrier barrier` ersetzt.
* Eine mögliche Problematik bei zwei Browser-Tabs, die auf den gleichen Port lauschen, ist in Issue #10 beschrieben
* Beim `load` erscheint für kurze Zeit die Anzeige "loading ..." rechts unten im Browser-Fenster
